### PR TITLE
[NO-TICKET] - Fix integration-deployment workflow

### DIFF
--- a/.github/workflows/integration-deployment.yml
+++ b/.github/workflows/integration-deployment.yml
@@ -26,7 +26,7 @@ jobs:
             const versionNumber = tagName.replace("v", "")
             core.setOutput('versionNumber', versionNumber)
       - name: Bump integration deployment version
-        uses: JupiterOne/integration-github-actions/create-integration-deployment@v1
+        uses: JupiterOne/integration-github-actions/create-integration-deployment@v2.0.1
         with:
           integrationName:
             ${{ steps.get-integration-name.outputs.integrationName }}


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

## Summary

Fixing the version of the github actions that is used to automatically create PRs in the `integration-deployments` repo when a new version of this package is published

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update
